### PR TITLE
Refactor: Simplify swipe navigation between home and archive

### DIFF
--- a/app/(tabs)/archive.tsx
+++ b/app/(tabs)/archive.tsx
@@ -1,81 +1,21 @@
-import { useRouter } from 'expo-router';
 import React from 'react';
-import { Dimensions } from 'react-native';
 import { PanGestureHandler } from 'react-native-gesture-handler';
-import Animated, {
-  runOnJS,
-  SlideInRight,
-  SlideOutLeft,
-  useAnimatedGestureHandler,
-  useAnimatedStyle,
-  useSharedValue,
-  withSpring
-} from 'react-native-reanimated';
+import Animated, { SlideInRight, SlideOutLeft } from 'react-native-reanimated';
 import ArchivePageWrapper from "../../components/ArchivePageWrapper";
-
-const SCREEN_WIDTH = Dimensions.get('window').width;
-const SWIPE_THRESHOLD = SCREEN_WIDTH * 0.3; // 30% of screen width
+import { useSwipeNavigation } from '../../hooks/useSwipeNavigation';
 
 export default function ArchiveTab() {
-  const router = useRouter();
-  const translateX = useSharedValue(0);
-  const isGestureActive = useSharedValue(false);
-
-  const navigateToEditor = () => {
-    router.push('/(tabs)/index');
-  };
-
-  const gestureHandler = useAnimatedGestureHandler({
-    onStart: (_, ctx: any) => {
-      ctx.startX = translateX.value;
-      isGestureActive.value = true;
-    },
-    onActive: (event, ctx) => {
-      // Only process right swipes and only if we're not already in a gesture
-      if (event.translationX > 0 && !isGestureActive.value) {
-        translateX.value = Math.min(SCREEN_WIDTH, ctx.startX + event.translationX);
-      }
-    },
-    onEnd: (event) => {
-      isGestureActive.value = false;
-      
-      if (event.translationX > SWIPE_THRESHOLD) {
-        // If swiped past threshold, navigate to editor
-        translateX.value = withSpring(SCREEN_WIDTH, {}, () => {
-          runOnJS(navigateToEditor)();
-        });
-      } else {
-        // Otherwise, spring back to start
-        translateX.value = withSpring(0);
-      }
-    },
-    onCancel: () => {
-      isGestureActive.value = false;
-      translateX.value = withSpring(0);
-    },
-    onFail: () => {
-      isGestureActive.value = false;
-      translateX.value = withSpring(0);
-    }
-  });
-
-  const animatedStyle = useAnimatedStyle(() => {
-    return {
-      transform: [{ translateX: translateX.value }],
-    };
-  });
+  const { gestureHandler, animatedStyle } = useSwipeNavigation('/(tabs)/index', 'right');
 
   return (
     <PanGestureHandler
       onGestureEvent={gestureHandler}
-      enabled={true}
-      shouldCancelWhenOutside={true}
       activeOffsetX={[-20, 20]} // Only activate after 20 pixels of movement
     >
-      <Animated.View 
+      <Animated.View
+        style={[{ flex: 1 }, animatedStyle]}
         entering={SlideInRight.duration(300)}
         exiting={SlideOutLeft.duration(300)}
-        style={[{ flex: 1 }, animatedStyle]}
       >
         <ArchivePageWrapper
           onLoadArchivedNote={(note) => {

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,82 +1,22 @@
-import { useRouter } from 'expo-router';
 import React, { useState } from 'react';
-import { Dimensions } from 'react-native';
 import { PanGestureHandler } from 'react-native-gesture-handler';
-import Animated, {
-  runOnJS,
-  SlideInRight,
-  SlideOutLeft,
-  useAnimatedGestureHandler,
-  useAnimatedStyle,
-  useSharedValue,
-  withSpring
-} from 'react-native-reanimated';
+import Animated, { SlideInRight, SlideOutLeft } from 'react-native-reanimated';
 import EditorPage from "../../components/EditorPage";
-
-const SCREEN_WIDTH = Dimensions.get('window').width;
-const SWIPE_THRESHOLD = SCREEN_WIDTH * 0.3; // 30% of screen width
+import { useSwipeNavigation } from '../../hooks/useSwipeNavigation';
 
 export default function EditorTab() {
   const [archivedNotes, setArchivedNotes] = useState<{ id: number; content: string }[]>([]);
-  const router = useRouter();
-  const translateX = useSharedValue(0);
-  const isGestureActive = useSharedValue(false);
-
-  const navigateToArchive = () => {
-    router.push('/(tabs)/archive');
-  };
-
-  const gestureHandler = useAnimatedGestureHandler({
-    onStart: (_, ctx: any) => {
-      ctx.startX = translateX.value;
-      isGestureActive.value = true;
-    },
-    onActive: (event, ctx) => {
-      // Only process left swipes and only if we're not already in a gesture
-      if (event.translationX < 0 && !isGestureActive.value) {
-        translateX.value = Math.max(-SCREEN_WIDTH, ctx.startX + event.translationX);
-      }
-    },
-    onEnd: (event) => {
-      isGestureActive.value = false;
-      
-      if (event.translationX < -SWIPE_THRESHOLD) {
-        // If swiped past threshold, navigate to archive
-        translateX.value = withSpring(-SCREEN_WIDTH, {}, () => {
-          runOnJS(navigateToArchive)();
-        });
-      } else {
-        // Otherwise, spring back to start
-        translateX.value = withSpring(0);
-      }
-    },
-    onCancel: () => {
-      isGestureActive.value = false;
-      translateX.value = withSpring(0);
-    },
-    onFail: () => {
-      isGestureActive.value = false;
-      translateX.value = withSpring(0);
-    }
-  });
-
-  const animatedStyle = useAnimatedStyle(() => {
-    return {
-      transform: [{ translateX: translateX.value }],
-    };
-  });
+  const { gestureHandler, animatedStyle } = useSwipeNavigation('/(tabs)/archive', 'left');
 
   return (
     <PanGestureHandler
       onGestureEvent={gestureHandler}
-      enabled={true}
-      shouldCancelWhenOutside={true}
       activeOffsetX={[-20, 20]} // Only activate after 20 pixels of movement
     >
-      <Animated.View 
+      <Animated.View
+        style={[{ flex: 1 }, animatedStyle]}
         entering={SlideInRight.duration(300)}
         exiting={SlideOutLeft.duration(300)}
-        style={[{ flex: 1 }, animatedStyle]}
       >
         <EditorPage
           archivedNotes={archivedNotes}

--- a/hooks/useSwipeNavigation.ts
+++ b/hooks/useSwipeNavigation.ts
@@ -1,0 +1,66 @@
+import { Dimensions } from 'react-native';
+import { useRouter } from 'expo-router';
+import { PanGestureHandler, PanGestureHandlerGestureEvent } from 'react-native-gesture-handler';
+import {
+  useSharedValue,
+  useAnimatedStyle,
+  withSpring,
+  runOnJS,
+  useAnimatedGestureHandler,
+} from 'react-native-reanimated';
+
+const { width: SCREEN_WIDTH } = Dimensions.get('window');
+const SWIPE_THRESHOLD = SCREEN_WIDTH * 0.3;
+
+type SwipeDirection = 'left' | 'right';
+
+export const useSwipeNavigation = (targetRoute: string, swipeDirection: SwipeDirection) => {
+  const router = useRouter();
+  const translateX = useSharedValue(0);
+
+  const gestureHandler = useAnimatedGestureHandler<PanGestureHandlerGestureEvent>({
+    onActive: (event) => {
+      if (swipeDirection === 'left') {
+        if (event.translationX < 0) {
+          translateX.value = Math.max(-SCREEN_WIDTH, event.translationX);
+        } else {
+          // If user drags right during a 'left' swipe, reset or keep at 0
+          translateX.value = 0;
+        }
+      } else { // swipeDirection === 'right'
+        if (event.translationX > 0) {
+          translateX.value = Math.min(SCREEN_WIDTH, event.translationX);
+        } else {
+          // If user drags left during a 'right' swipe, reset or keep at 0
+          translateX.value = 0;
+        }
+      }
+    },
+    onEnd: (event) => {
+      const translationX = event.translationX;
+      let shouldNavigate = false;
+
+      if (swipeDirection === 'left' && translationX < -SWIPE_THRESHOLD) {
+        shouldNavigate = true;
+        translateX.value = withSpring(-SCREEN_WIDTH, {}, () => {
+          runOnJS(router.navigate)(targetRoute);
+        });
+      } else if (swipeDirection === 'right' && translationX > SWIPE_THRESHOLD) {
+        shouldNavigate = true;
+        translateX.value = withSpring(SCREEN_WIDTH, {}, () => {
+          runOnJS(router.navigate)(targetRoute);
+        });
+      }
+
+      if (!shouldNavigate) {
+        translateX.value = withSpring(0);
+      }
+    },
+  });
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: translateX.value }],
+  }));
+
+  return { gestureHandler, animatedStyle };
+};


### PR DESCRIPTION
This commit refactors the swipe navigation logic for the home (Editor) and archive screens.

Key changes:
- Introduced a reusable `useSwipeNavigation` hook to encapsulate PanGestureHandler logic, animations, and navigation.
- Removed redundant gesture handling code from individual screen components (`app/(tabs)/index.tsx` and `app/(tabs)/archive.tsx`).
- Simplified the gesture detection logic within the hook, removing unnecessary state variables and ensuring cleaner conditions for swipe activation and navigation.
- Navigation is now handled by `router.navigate` to correctly switch between tabs rather than pushing to the history stack.

This resolves issues with buggy or overly complex swipe behavior and makes the navigation code more maintainable and minimal.